### PR TITLE
Change to amplify.yml file

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -5,6 +5,8 @@ frontend:
       commands:
         - nvm use $VERSION_NODE_12
         - npm ci
+        - rm -rf node_modules
+        - npm install
     build:
       commands:
         - nvm use $VERSION_NODE_12


### PR DESCRIPTION

## Description ##

Temporary change to amplify.yml file to force it to delete cached node modules upon build.  This file will be changed back in a subsequent pull request.  This is one recommended method to correcting possible build failures which cause the redirects upon login to error.

- [X] This is a bugfix.

## Organization ##

- [X] Have you linked this pull request to a Trello card?

